### PR TITLE
Fixing a bug in sequence preprocessing

### DIFF
--- a/tr_rosetta_pytorch/utils.py
+++ b/tr_rosetta_pytorch/utils.py
@@ -83,7 +83,7 @@ def preprocess(msa_file, wmin=0.8, ns=21):
 
     # 2d sequence
 
-    f2d_dca = fast_dca(msa1hot, w) if nrow > 1 else torch.zeros((ncol, ncol, 442)).float()
+    f2d_dca = fast_dca(msa1hot, w) if nrow > 1 else torch.zeros((ncol, ncol, 442)).float().to(d())
     f2d_dca = f2d_dca[None, :, :, :]
 
     f2d = torch.cat((


### PR DESCRIPTION
When cuda is available, and a sequence of length = 1 is loaded, it is left on the cpu and not copied to the gpu. That creates an error: 
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking arugment for argument tensors in method wrapper__cat)`